### PR TITLE
fix: SignUpInput Props 타입 수정

### DIFF
--- a/src/components/SignUpInput.tsx
+++ b/src/components/SignUpInput.tsx
@@ -12,10 +12,10 @@ export default function SignUpInput({
   children,
   ...props
 }: SignUpInputProps &
-  (
-    | Omit<React.ComponentPropsWithoutRef<"input">, keyof SignUpInputProps>
-    | "className"
-  )) {
+  Omit<
+    React.ComponentPropsWithoutRef<"input">,
+    keyof SignUpInputProps | "className"
+  >) {
   return (
     <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)] flex flex-col gap-2">
       <label htmlFor={id} className="text-white">


### PR DESCRIPTION
- Closes #44

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

`npm run build`를 했을 때 SignUpInput Props 타입에서 오류가 발생했고, 해당 오류를 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

코드를 확인해보니 Props 타입이 `Props & Omit<ComponentPropsWithoutRef<"input">, keyof Props | "className">`이 아닌 `Props & (Omit<ComponentPropsWithoutRef<"input">, keyof Props> | "className")`으로 되어있었고, 해당 코드를 원래 작성하려던대로 수정했습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
