### PR TITLE
fix: SignUpInput을 Input 컴포넌트로 변경

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,24 +1,27 @@
 import React from "react";
 
-interface SignUpInputProps {
+interface InputProps {
   id: string;
   label: string;
   children?: React.ReactNode;
 }
 
-export default function SignUpInput({
+export default function Input({
   id,
   label,
   children,
   ...props
-}: SignUpInputProps &
+}: InputProps &
   Omit<
     React.ComponentPropsWithoutRef<"input">,
-    keyof SignUpInputProps | "className"
+    keyof InputProps | "className"
   >) {
   return (
-    <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)] flex flex-col gap-2">
-      <label htmlFor={id} className="text-white">
+    <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)] flex flex-col gap-1">
+      <label
+        htmlFor={id}
+        className="text-sm text-white/50 mix-blend-difference"
+      >
         {label}
       </label>
       <div className="relative">


### PR DESCRIPTION
- Closes #46

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

기존에 SignUpInput과 TruckInput으로 구분됐던 컴포넌트의 생김새가 동일해서 해당 컴포넌트를 동일한 컴포넌트로 사용할 수 있게 변경했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- `SignUpInput`의 이름을 `Input`으로 변경했습니다.
- label 텍스트 컬러를 `text-white`에서 **`text-white/50 mix-blend-difference`으로 변경**했습니다.
  - white와 gray로 나누는 것보다 label을 함께 사용하는 **Input 컴포넌트가 사용되는 배경이 black/white**라서 blendmode만 변경하는 방식으로 만드는 것도 괜찮아보여 해당 방법을 선택했습니다.
  - white 100% + difference를 적용하면 **배경이 white일 때 label만 둥둥 떠다니는 느낌이라서 `white/50`을 적용**했습니다.
    | `white 100%` | `white 50%` |
    |--|--|
    | ![image](https://github.com/user-attachments/assets/48252705-0812-4cda-8d73-1300db2f3c81) | ![image](https://github.com/user-attachments/assets/a0e12c2b-db3d-4413-8b05-4e8aca40272c) |

- label 텍스트 사이즈를 default 사이즈에서 `text-sm`으로 변경하면서 기존에 `gap-2`를 `gap-1`로 변경했습니다.
  | `text-default, gap-2` | `text-sm, gap-1` |
  |--|--|
  | ![image](https://github.com/user-attachments/assets/8db32522-ca95-42a4-8293-dbd7232999fc) | ![image](https://github.com/user-attachments/assets/cadf1fbf-4bf8-4791-89c9-f0fb77c53b2b) |

### 🖼️ 최종 결과물

| `bg-black` | `bg-white` |
|--|--|
| ![image](https://github.com/user-attachments/assets/af618737-f805-4e57-b14f-3b1264b3fb8f) | ![image](https://github.com/user-attachments/assets/a0e12c2b-db3d-4413-8b05-4e8aca40272c) |

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

추가적으로 수정할 부분 있으면 코멘트 남겨주세요..!!