### PR TITLE
feat: zustand로 title 전역관리 및 topbar 수정

### DIFF
--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -1,46 +1,44 @@
-import LeftArrowIcon from "../assets/images/leftArrow.svg?react";
-import { useLocation, useNavigate } from "react-router-dom";
-import BookMarkButton from "../components/BookMarkButton";
+import LeftArrowIcon from '../assets/images/leftArrow.svg?react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import BookMarkButton from '../components/BookMarkButton';
 
 type TopBarProps = {
-  title?: string;
+    title?: string;
 };
 
 export default function TopBar({ title }: TopBarProps) {
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
+    const navigate = useNavigate();
+    const { pathname } = useLocation();
 
-  const onClickLeft = () => {
-    if (document.startViewTransition) {
-      document.startViewTransition(() => {
-        navigate(-1);
-      });
-    } else {
-      navigate(-1);
-    }
-  };
+    const onClickLeft = () => {
+        if (document.startViewTransition) {
+            document.startViewTransition(() => {
+                navigate(-1);
+            });
+        } else {
+            navigate(-1);
+        }
+    };
 
-  const onClickRight = () => {};
+    const onClickRight = () => {};
 
-  return (
-    <div className="flex w-full bg-primary justify-center items-center px-4 py-4 sticky top-0">
-      {pathname === "/detail" && (
-        <div className="flex items-center gap-4">
-          <div onClick={onClickLeft}>
-            <LeftArrowIcon
-              width={20}
-              height={20}
-              className="fill-white cursor-pointer"
-            />
-          </div>
+    return (
+        <div className="flex w-full bg-primary justify-center items-center px-4 py-5 sticky top-0">
+            <div className="w-[calc(100%-50px)] sm:w-[calc(100%-100px)] flex">
+                {(pathname === '/detail' || pathname === '/register') && (
+                    <div className="flex items-center gap-4">
+                        <div onClick={onClickLeft}>
+                            <LeftArrowIcon width={20} height={20} className="fill-white cursor-pointer" />
+                        </div>
+                    </div>
+                )}
+                <p className="flex-1 text-center text-lg text-white font-bold">{title}</p>
+                {pathname === '/detail' && (
+                    <div className="flex justify-end items-center gap-spacing-05">
+                        <BookMarkButton isBookmarked={false} onClick={onClickRight} size={30} />
+                    </div>
+                )}
+            </div>
         </div>
-      )}
-      <p className="flex-1 text-center text-lg text-white">{title}</p>
-      {pathname === "/detail" && (
-        <div className="flex justify-end items-center gap-spacing-05">
-          <BookMarkButton isBookmarked={false} onClick={onClickRight} />
-        </div>
-      )}
-    </div>
-  );
+    );
 }

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -1,23 +1,22 @@
-import { Outlet, useLocation } from "react-router-dom";
-import TopBar from "./TopBar.tsx";
-import BottomNavBar from "./BottomNavBar.tsx";
+import { Outlet, useLocation } from 'react-router-dom';
+import TopBar from './TopBar.tsx';
+import BottomNavBar from './BottomNavBar.tsx';
+import useTitleStore from '../store/titleStore.ts';
 
 export default function RootLayout() {
-  const { pathname } = useLocation();
-  return (
-    <div className="antialiased min-h-screen bg-black/30 flex justify-center">
-      <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
-        {/* 자식 라우트가 렌더링될 위치 */}
-        {["/my-truck", "/detail", "/bookmark"].includes(pathname) && (
-          <TopBar title="Title" />
-        )}
-        <div className="flex-1">
-          <Outlet />
+    const { pathname } = useLocation();
+    //store에 있는 상태를 가져온다
+    const title = useTitleStore((state) => state.title);
+    return (
+        <div className="antialiased min-h-screen bg-black/30 flex justify-center">
+            <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
+                {/* 자식 라우트가 렌더링될 위치 */}
+                {['/my-truck', '/detail', '/bookmark', '/register'].includes(pathname) && <TopBar title={title} />}
+                <div className="flex-1">
+                    <Outlet />
+                </div>
+                {!['/', '/login', '/signup', '/detail'].includes(pathname) && <BottomNavBar />}
+            </div>
         </div>
-        {!["/", "/login", "/signup", "/detail"].includes(pathname) && (
-          <BottomNavBar />
-        )}
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/pages/owner/MyTruckPage.tsx
+++ b/src/pages/owner/MyTruckPage.tsx
@@ -1,3 +1,18 @@
+import { useEffect } from 'react';
+import useTitleStore from '../../store/titleStore';
+import { useNavigate } from 'react-router-dom';
+
 export default function MyTruckPage() {
-  return <div>MyTruck</div>;
+    const setTitle = useTitleStore((state) => state.setTitle);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        setTitle('내 가게');
+    }, []);
+
+    return (
+        <div>
+            <button onClick={() => navigate(`/register`)}>내 가게 등록하기</button>
+        </div>
+    );
 }

--- a/src/pages/owner/RegisterPage.tsx
+++ b/src/pages/owner/RegisterPage.tsx
@@ -1,3 +1,12 @@
+import { useEffect } from 'react';
+import useTitleStore from '../../store/titleStore';
+
 export default function RegisterPage() {
-  return <div>Register</div>;
+    const setTitle = useTitleStore((state) => state.setTitle);
+
+    useEffect(() => {
+        setTitle('가게 등록');
+    }, []);
+
+    return <div>Register</div>;
 }

--- a/src/store/titleStore.ts
+++ b/src/store/titleStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface TitleState {
+    title: string;
+    setTitle: (newTitle: string) => void;
+}
+
+const useTitleStore = create<TitleState>((set) => ({
+    title: 'Title',
+    setTitle: (newTitle) => set({ title: newTitle }),
+}));
+
+export default useTitleStore;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
zustand로 topbar에 title을 전역관리하도록 수정했습니다.
topbar style을 조금 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
<img width="400" alt="화면 캡처 2024-10-25 154752" src="https://github.com/user-attachments/assets/c298df04-e03d-430e-a9a7-b0cd4c67bbf4">
<img width="400" alt="화면 캡처 2024-10-25 154811" src="https://github.com/user-attachments/assets/1389d69a-a80d-463c-a77b-17f2d870edb6">

위와 같이 수정하였고,
/register로 갔을 때도 topbar가 나오도록 수정했습니다.
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
