### PR TITLE
design: 카테고리 리스트 퍼블리싱

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -35,7 +35,7 @@ export default function Category({ isOpen, setOpen }: CategoryProps) {
       initialSnap={1}
     >
       <Sheet.Container>
-        <Sheet.Header />
+        <Sheet.Header className="relative top-[1px]" />
         <Sheet.Content className="overflow-auto">
           <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)]">
             <p className="text-white font-bold text-lg sm:text-xl py-8">

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,6 +1,7 @@
 import { Sheet } from "react-modal-sheet";
 import Menu from "./Menu.tsx";
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface CategoryProps {
   isOpen: boolean;
@@ -8,6 +9,7 @@ interface CategoryProps {
 }
 
 export default function Category({ isOpen, setOpen }: CategoryProps) {
+  const navigate = useNavigate();
   // 임시 데이터
   const [categories] = useState<
     { title: string; Img?: React.FC<{ width?: number; height?: number }> }[]
@@ -18,6 +20,13 @@ export default function Category({ isOpen, setOpen }: CategoryProps) {
     }[],
   );
 
+  const handleCategoryClick = (target: string) => {
+    setOpen(false);
+    // 카테고리 필터 적용 후 Map으로 이동
+    console.log(target);
+    navigate(`/map`);
+  };
+
   return (
     <Sheet
       isOpen={isOpen}
@@ -27,7 +36,6 @@ export default function Category({ isOpen, setOpen }: CategoryProps) {
     >
       <Sheet.Container>
         <Sheet.Header />
-        <Sheet.Content>{/* Your sheet content goes here */}</Sheet.Content>
         <Sheet.Content className="overflow-auto">
           <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)]">
             <p className="text-white font-bold text-lg sm:text-xl py-8">
@@ -39,6 +47,7 @@ export default function Category({ isOpen, setOpen }: CategoryProps) {
                   <div
                     key={`category_${idx}`}
                     className="cursor-pointer"
+                    onClick={() => handleCategoryClick(title)}
                   >
                     <Menu title={title} />
                   </div>

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,20 +1,23 @@
-import { Sheet } from 'react-modal-sheet';
-import { useState } from 'react';
+import { Sheet } from "react-modal-sheet";
 
-export default function Category() {
-    //지금은 안에 state로 되어있지만 props로 받아서 열고닫기해줘야합니다..
-    const [isOpen, setOpen] = useState(false);
-    return (
-        <>
-            <button onClick={() => setOpen(true)}>Open sheet</button>
+interface CategoryProps {
+  isOpen: boolean;
+  setOpen: (isOpen: boolean) => void;
+}
 
-            <Sheet isOpen={isOpen} onClose={() => setOpen(false)} snapPoints={[-50, 0.5, 100, 0]} initialSnap={1}>
-                <Sheet.Container>
-                    <Sheet.Header />
-                    <Sheet.Content>{/* Your sheet content goes here */}</Sheet.Content>
-                </Sheet.Container>
-                <Sheet.Backdrop />
-            </Sheet>
-        </>
-    );
+export default function Category({ isOpen, setOpen }: CategoryProps) {
+  return (
+    <Sheet
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      snapPoints={[-50, 0.5, 100, 0]}
+      initialSnap={1}
+    >
+      <Sheet.Container>
+        <Sheet.Header />
+        <Sheet.Content>{/* Your sheet content goes here */}</Sheet.Content>
+      </Sheet.Container>
+      <Sheet.Backdrop />
+    </Sheet>
+  );
 }

--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -1,4 +1,6 @@
 import { Sheet } from "react-modal-sheet";
+import Menu from "./Menu.tsx";
+import React, { useState } from "react";
 
 interface CategoryProps {
   isOpen: boolean;
@@ -6,6 +8,16 @@ interface CategoryProps {
 }
 
 export default function Category({ isOpen, setOpen }: CategoryProps) {
+  // 임시 데이터
+  const [categories] = useState<
+    { title: string; Img?: React.FC<{ width?: number; height?: number }> }[]
+  >(
+    Array.from({ length: 14 }).fill({ title: "붕어빵" }) as {
+      title: string;
+      Img?: React.FC<{ width?: number; height?: number }>;
+    }[],
+  );
+
   return (
     <Sheet
       isOpen={isOpen}
@@ -16,6 +28,25 @@ export default function Category({ isOpen, setOpen }: CategoryProps) {
       <Sheet.Container>
         <Sheet.Header />
         <Sheet.Content>{/* Your sheet content goes here */}</Sheet.Content>
+        <Sheet.Content className="overflow-auto">
+          <div className="mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-200px)]">
+            <p className="text-white font-bold text-lg sm:text-xl py-8">
+              우리 동네 길거리음식, 찾아보세요!
+            </p>
+            <Sheet.Scroller>
+              <div className="grid grid-cols-[repeat(auto-fit,75px)] gap-x-4 sm:gap-x-10 gap-y-8 justify-between">
+                {categories.map(({ title }, idx) => (
+                  <div
+                    key={`category_${idx}`}
+                    className="cursor-pointer"
+                  >
+                    <Menu title={title} />
+                  </div>
+                ))}
+              </div>
+            </Sheet.Scroller>
+          </div>
+        </Sheet.Content>
       </Sheet.Container>
       <Sheet.Backdrop />
     </Sheet>

--- a/src/layouts/BottomNavBar.tsx
+++ b/src/layouts/BottomNavBar.tsx
@@ -5,13 +5,22 @@ import StarIcon from "../assets/images/star.svg?react";
 import MapIcon from "../assets/images/map.svg?react";
 import CategoryIcon from "../assets/images/category.svg?react";
 
-const BottomNavBar = () => {
+interface BottomNavBarProps {
+  isOpenCategory: boolean;
+  setOpenCategory: (isOpen: boolean | ((prev: boolean) => boolean)) => void;
+}
+
+const BottomNavBar = ({
+  isOpenCategory,
+  setOpenCategory,
+}: BottomNavBarProps) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [isOwner] = useState(true); // 사장님인지 아닌지
 
   // 라우팅 경로를 처리하는 함수입니다
   const handleClick = (path: string) => {
+    setOpenCategory(false);
     if (document.startViewTransition) {
       document.startViewTransition(() => {
         navigate(path);
@@ -21,7 +30,7 @@ const BottomNavBar = () => {
     }
   };
 
-  const isFocused = (path: string) => pathname === path;
+  const isFocused = (path: string) => !isOpenCategory && pathname === path;
 
   return (
     <div className="flex bg-black text-xs sticky bottom-0 z-[999999999]">
@@ -40,13 +49,12 @@ const BottomNavBar = () => {
       <div
         className={[
           "flex flex-col flex-1 py-4 gap-1 items-center justify-center cursor-pointer",
-          isFocused("/category")
+          isOpenCategory
             ? "text-primary stroke-primary"
             : "text-white stroke-white",
         ].join(" ")}
-        onClick={() => handleClick("/map")}
+        onClick={() => setOpenCategory((prev) => !prev)}
       >
-        {/* Category 클릭 시 바텀시트 오픈 */}
         <CategoryIcon width={24} height={24} />
         <p>카테고리</p>
       </div>

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -1,22 +1,34 @@
-import { Outlet, useLocation } from 'react-router-dom';
-import TopBar from './TopBar.tsx';
-import BottomNavBar from './BottomNavBar.tsx';
-import useTitleStore from '../store/titleStore.ts';
+import { Outlet, useLocation } from "react-router-dom";
+import TopBar from "./TopBar.tsx";
+import BottomNavBar from "./BottomNavBar.tsx";
+import useTitleStore from "../store/titleStore.ts";
+import { useState } from "react";
+import Category from "../components/Category.tsx";
 
 export default function RootLayout() {
-    const { pathname } = useLocation();
-    //store에 있는 상태를 가져온다
-    const title = useTitleStore((state) => state.title);
-    return (
-        <div className="antialiased min-h-screen bg-black/30 flex justify-center">
-            <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
-                {/* 자식 라우트가 렌더링될 위치 */}
-                {['/my-truck', '/detail', '/bookmark', '/register'].includes(pathname) && <TopBar title={title} />}
-                <div className="flex-1">
-                    <Outlet />
-                </div>
-                {!['/', '/login', '/signup', '/detail'].includes(pathname) && <BottomNavBar />}
-            </div>
+  const { pathname } = useLocation();
+  const [isOpenCategory, setIsOpenCategory] = useState(false);
+
+  //store에 있는 상태를 가져온다
+  const title = useTitleStore((state) => state.title);
+  return (
+    <div className="antialiased min-h-screen bg-black/30 flex justify-center">
+      <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
+        {/* 자식 라우트가 렌더링될 위치 */}
+        {["/my-truck", "/detail", "/bookmark", "/register"].includes(
+          pathname,
+        ) && <TopBar title={title} />}
+        <div className="flex-1">
+          <Outlet />
         </div>
-    );
+        <Category isOpen={isOpenCategory} setOpen={setIsOpenCategory} />
+        {!["/", "/login", "/signup", "/detail"].includes(pathname) && (
+          <BottomNavBar
+            isOpenCategory={isOpenCategory}
+            setOpenCategory={setIsOpenCategory}
+          />
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

바텀시트 안쪽에 출력되는 리스트를 퍼블리싱했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

### 디자인 시안

![image](https://github.com/user-attachments/assets/bffc7b8d-1c3d-47bd-a3d6-f98a109256ef)

### 실제 페이지

| Desktop | Mobile |
|--|--|
| ![category-desktop](https://github.com/user-attachments/assets/1577304c-2ccb-464b-81b4-fa212985a5f8) | ![category-mobile](https://github.com/user-attachments/assets/e16713d5-02d1-463e-9bd8-2d2f01ee5c4d) |

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

- BottomNavBar의 카테고리 메뉴 클릭 시 카테고리 바텀시트가 열리도록 수정했습니다.
  - 바텀시트 열린 상태에서 다른 메뉴 클릭 시 바텀시트가 닫히고 다른 메뉴로 이동됩니다.
  - 바텀시트 내부의 카테고리 메뉴 클릭 시 바텀시트가 닫히고 MapPage로 이동됩니다.