### PR TITLE
feat: Detail 페이지 path 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,34 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import './index.css';
-import RootLayout from './layouts/layout';
-import MainPage from './pages/MainPage.tsx';
-import LoginPage from './pages/LoginPage.tsx';
-import SignUpPage from './pages/SignUpPage.tsx';
-import MapPage from './pages/MapPage.tsx';
-import RegisterPage from './pages/owner/RegisterPage.tsx';
-import MyTruckPage from './pages/owner/MyTruckPage.tsx';
-import DetailPage from './pages/DetailPage.tsx';
-import BookMarkPage from './pages/BookMarkPage.tsx';
-import NotificationPage from './pages/NotificationPage.tsx';
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import "./index.css";
+import RootLayout from "./layouts/layout";
+import MainPage from "./pages/MainPage.tsx";
+import LoginPage from "./pages/LoginPage.tsx";
+import SignUpPage from "./pages/SignUpPage.tsx";
+import MapPage from "./pages/MapPage.tsx";
+import RegisterPage from "./pages/owner/RegisterPage.tsx";
+import MyTruckPage from "./pages/owner/MyTruckPage.tsx";
+import DetailPage from "./pages/DetailPage.tsx";
+import BookMarkPage from "./pages/BookMarkPage.tsx";
+import NotificationPage from "./pages/NotificationPage.tsx";
 
 function App() {
-    return (
-        <Router>
-            <Routes>
-                <Route path="/" element={<RootLayout />}>
-                    <Route index={true} element={<MainPage />} />
-                    <Route path="/login" element={<LoginPage />} />
-                    <Route path="/signup" element={<SignUpPage />} />
-                    <Route path="/map" element={<MapPage />} />
-                    <Route path="/bookmark" element={<BookMarkPage />} />
-                    <Route path="/detail" element={<DetailPage />} />
-                    <Route path="/my-truck" element={<MyTruckPage />} />
-                    <Route path="/register" element={<RegisterPage />} />
-                    <Route path="/notification" element={<NotificationPage />} />
-                </Route>
-            </Routes>
-        </Router>
-    );
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<RootLayout />}>
+          <Route index={true} element={<MainPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignUpPage />} />
+          <Route path="/map" element={<MapPage />} />
+          <Route path="/bookmark" element={<BookMarkPage />} />
+          <Route path="/detail/:id" element={<DetailPage />} />
+          <Route path="/my-truck" element={<MyTruckPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/notification" element={<NotificationPage />} />
+        </Route>
+      </Routes>
+    </Router>
+  );
 }
 
 export default App;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,54 +1,76 @@
-import BookMarkButton from './BookMarkButton';
-import Menu from '../assets/images/defaultMenu.svg?react';
-interface CardProps {
-    isOpen: boolean;
-    info: {
-        category: string;
-        name: string;
-        visited: number;
-    };
-    bg: string;
-}
-export default function Card({ isOpen = false, info, bg = 'black' }: CardProps) {
-    const handleClick = () => {};
+import BookMarkButton from "./BookMarkButton";
+import Menu from "../assets/images/defaultMenu.svg?react";
+import useFadeNavigate from "../hooks/useFadeNavigate.ts";
 
-    return (
-        <div
-            className={`bg-${bg} mx-auto w-[calc(100%-50px)] sm:w-full rounded-2xl p-6 flex flex-col gap-y-5 ${
-                bg === 'white' ? 'drop-shadow-lg' : null
-            }`}
-        >
-            <div className="tracking-tight flex gap-x-3">
-                <div className="flex-none flex items-center justify-center">
-                    <Menu width={90} height={90} />
-                </div>
-                <div className="flex flex-col justify-center gap-y-2">
-                    <div className="text-xs text-category">카테고리 {info.category}</div>
-                    <div className={`${bg === 'white' ? 'text-black' : 'text-white'} font-bold text-base`}>
-                        이름 {info.name}
-                    </div>
-                    <div className="gap-x-1 text-xs text-category bg-count px-2 py-1 rounded-2xl whitespace-nowrap inline-flex max-w-fit">
-                        <span>최근 방문</span>
-                        <span className="text-white">{info.visited}명</span>
-                    </div>
-                </div>
-                <div className="flex-1 flex flex-col gap-y-2 pt-2">
-                    <div className="flex justify-end">
-                        <BookMarkButton isBookmarked={true} onClick={handleClick} size={30} />
-                    </div>
-                    <div className="flex justify-end text-xs gap-x-1 text-white items-center">
-                        <div className={`w-1 h-1 rounded-full ${isOpen ? 'bg-success' : 'bg-red-500'}`}></div>
-                        <div className={`whitespace-nowrap ${bg === 'white' ? 'text-black' : 'text-white'}`}>
-                            {isOpen ? '운영중' : '운영종료'}
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div className="text-right">
-                <button className="text-right bg-primary text-base py-2 px-3 tracking-tight rounded-md text-white font-bold">
-                    자세히 보기
-                </button>
-            </div>
+interface CardProps {
+  isOpen: boolean;
+  info: {
+    id: string;
+    category: string;
+    name: string;
+    visited: number;
+  };
+  bg: string;
+}
+export default function Card({
+  isOpen = false,
+  info,
+  bg = "black",
+}: CardProps) {
+  const navigate = useFadeNavigate();
+
+  const handleClick = () => {};
+
+  return (
+    <div
+      className={`bg-${bg} mx-auto w-[calc(100%-50px)] sm:w-full rounded-2xl p-6 flex flex-col gap-y-5 ${
+        bg === "white" ? "drop-shadow-lg" : null
+      }`}
+    >
+      <div className="tracking-tight flex gap-x-3">
+        <div className="flex-none flex items-center justify-center">
+          <Menu width={90} height={90} />
         </div>
-    );
+        <div className="flex flex-col justify-center gap-y-2">
+          <div className="text-xs text-category">카테고리 {info.category}</div>
+          <div
+            className={`${bg === "white" ? "text-black" : "text-white"} font-bold text-base`}
+          >
+            이름 {info.name}
+          </div>
+          <div className="gap-x-1 text-xs text-category bg-count px-2 py-1 rounded-2xl whitespace-nowrap inline-flex max-w-fit">
+            <span>최근 방문</span>
+            <span className="text-white">{info.visited}명</span>
+          </div>
+        </div>
+        <div className="flex-1 flex flex-col gap-y-2 pt-2">
+          <div className="flex justify-end">
+            <BookMarkButton
+              isBookmarked={true}
+              onClick={handleClick}
+              size={30}
+            />
+          </div>
+          <div className="flex justify-end text-xs gap-x-1 text-white items-center">
+            <div
+              className={`w-1 h-1 rounded-full ${isOpen ? "bg-success" : "bg-red-500"}`}
+            ></div>
+            <div
+              className={`whitespace-nowrap ${bg === "white" ? "text-black" : "text-white"}`}
+            >
+              {isOpen ? "운영중" : "운영종료"}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="text-right">
+        <button
+          className="text-right bg-primary text-base py-2 px-3 tracking-tight rounded-md text-white font-bold"
+          onClick={() => navigate(`/detail/${info.id}`)}
+        >
+          자세히 보기
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -1,52 +1,69 @@
-import LeftArrowIcon from '../assets/images/leftArrow.svg?react';
-import { useLocation } from 'react-router-dom';
-import BookMarkButton from '../components/BookMarkButton';
-import useFadeNavigate from '../hooks/useFadeNavigate';
-import Notification from '../assets/images/noti.svg?react';
+import LeftArrowIcon from "../assets/images/leftArrow.svg?react";
+import { useLocation } from "react-router-dom";
+import BookMarkButton from "../components/BookMarkButton";
+import useFadeNavigate from "../hooks/useFadeNavigate";
+import Notification from "../assets/images/noti.svg?react";
+import { useMemo } from "react";
 
 type TopBarProps = {
-    title?: string;
+  title?: string;
 };
 
 export default function TopBar({ title }: TopBarProps) {
-    const navigate = useFadeNavigate();
-    const { pathname } = useLocation();
+  const navigate = useFadeNavigate();
+  const { pathname: _pathname } = useLocation();
 
-    const onClickLeft = () => {
-        if (document.startViewTransition) {
-            document.startViewTransition(() => {
-                navigate(-1);
-            });
-        } else {
-            navigate(-1);
-        }
-    };
+  const pathname = useMemo(() => `/${_pathname.split("/")[1]}`, [_pathname]);
 
-    const onClickRight = () => {};
+  const onClickLeft = () => {
+    if (document.startViewTransition) {
+      document.startViewTransition(() => {
+        navigate(-1);
+      });
+    } else {
+      navigate(-1);
+    }
+  };
 
-    return (
-        <div className="flex w-full bg-primary justify-center items-center px-4 py-5 sticky top-0 z-10">
-            <div className="w-[calc(100%-50px)] sm:w-[calc(100%-100px)] flex items-center">
-                <div className="flex-1 flex items-center">
-                    {(pathname === '/detail' || pathname === '/register' || pathname === '/notification') && (
-                        <div onClick={onClickLeft}>
-                            <LeftArrowIcon width={25} height={25} className="fill-white cursor-pointer" />
-                        </div>
-                    )}
-                </div>
-                <p className="flex-1 text-center text-lg text-white font-bold">{title}</p>
-                <div className="flex-1 flex items-center justify-end">
-                    {pathname === '/detail' && <BookMarkButton isBookmarked={false} onClick={onClickRight} size={30} />}
-                    {pathname === '/bookmark' && (
-                        <Notification
-                            width={25}
-                            height={25}
-                            className="cursor-pointer"
-                            onClick={() => navigate(`/notification`)}
-                        />
-                    )}
-                </div>
+  const onClickRight = () => {};
+
+  return (
+    <div className="flex w-full bg-primary justify-center items-center px-4 py-5 sticky top-0 z-10">
+      <div className="w-[calc(100%-50px)] sm:w-[calc(100%-100px)] flex items-center">
+        <div className="flex-1 flex items-center">
+          {(pathname === "/detail" ||
+            pathname === "/register" ||
+            pathname === "/notification") && (
+            <div onClick={onClickLeft}>
+              <LeftArrowIcon
+                width={25}
+                height={25}
+                className="fill-white cursor-pointer"
+              />
             </div>
+          )}
         </div>
-    );
+        <p className="flex-1 text-center text-lg text-white font-bold">
+          {title}
+        </p>
+        <div className="flex-1 flex items-center justify-end">
+          {pathname === "/detail" && (
+            <BookMarkButton
+              isBookmarked={false}
+              onClick={onClickRight}
+              size={30}
+            />
+          )}
+          {pathname === "/bookmark" && (
+            <Notification
+              width={25}
+              height={25}
+              className="cursor-pointer"
+              onClick={() => navigate(`/notification`)}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/layouts/layout.tsx
+++ b/src/layouts/layout.tsx
@@ -1,31 +1,42 @@
-import { Outlet, useLocation } from 'react-router-dom';
-import TopBar from './TopBar.tsx';
-import BottomNavBar from './BottomNavBar.tsx';
-import useTitleStore from '../store/titleStore.ts';
-import { useState } from 'react';
-import Category from '../components/Category.tsx';
+import { Outlet, useLocation } from "react-router-dom";
+import TopBar from "./TopBar.tsx";
+import BottomNavBar from "./BottomNavBar.tsx";
+import useTitleStore from "../store/titleStore.ts";
+import { useMemo, useState } from "react";
+import Category from "../components/Category.tsx";
 
 export default function RootLayout() {
-    const { pathname } = useLocation();
-    const [isOpenCategory, setIsOpenCategory] = useState(false);
+  const { pathname: _pathname } = useLocation();
+  const [isOpenCategory, setIsOpenCategory] = useState(false);
 
-    //store에 있는 상태를 가져온다
-    const title = useTitleStore((state) => state.title);
-    return (
-        <div className="antialiased min-h-screen bg-black/30 flex justify-center">
-            <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
-                {/* 자식 라우트가 렌더링될 위치 */}
-                {['/my-truck', '/detail', '/bookmark', '/register', '/notification'].includes(pathname) && (
-                    <TopBar title={title} />
-                )}
-                <div className="flex-1">
-                    <Outlet />
-                </div>
-                <Category isOpen={isOpenCategory} setOpen={setIsOpenCategory} />
-                {!['/', '/login', '/signup', '/detail', '/register'].includes(pathname) && (
-                    <BottomNavBar isOpenCategory={isOpenCategory} setOpenCategory={setIsOpenCategory} />
-                )}
-            </div>
+  const pathname = useMemo(() => `/${_pathname.split("/")[1]}`, [_pathname]);
+
+  //store에 있는 상태를 가져온다
+  const title = useTitleStore((state) => state.title);
+  return (
+    <div className="antialiased min-h-screen bg-black/30 flex justify-center">
+      <div className="relative max-w-[768px] w-full min-h-screen bg-white flex flex-col justify-center">
+        {/* 자식 라우트가 렌더링될 위치 */}
+        {[
+          "/my-truck",
+          "/detail",
+          "/bookmark",
+          "/register",
+          "/notification",
+        ].includes(pathname) && <TopBar title={title} />}
+        <div className="flex-1">
+          <Outlet />
         </div>
-    );
+        <Category isOpen={isOpenCategory} setOpen={setIsOpenCategory} />
+        {!["/", "/login", "/signup", "/detail", "/register"].includes(
+          pathname,
+        ) && (
+          <BottomNavBar
+            isOpenCategory={isOpenCategory}
+            setOpenCategory={setIsOpenCategory}
+          />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -122,6 +122,7 @@ export default function MapPage() {
             <Card
               isOpen={false}
               info={{
+                id: clickMarker._id,
                 category: clickMarker.category,
                 name: clickMarker.name,
                 visited: 0,


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

Detail 페이지 path 변경했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

변경되면서 아래 파일 수정했습니다.

### `App.tsx` 

detail page의 path를 수정했습니다.

### `MapPage.tsx` / `Card.tsx`

Card에 prop으로 storeId를 넘겨 자세히버튼 클릭 시 detail/:id로 이동되도록 수정했습니다.

### `layout.tsx` / `TopBar.tsx`

detail path가 수정되면서 적용되지 않던 레이아웃들을 수정했습니다.

### 추가 내용

현재 build 시 오류가 발생합니다.

오류가 발생하는 원인은 Card 컴포넌트에 id를 추가하면서 DB 데이터와 동일하게 string으로 입력했는데 기존에 작성되어있던 Bookmark mock 데이터의 id가 number로 되어있어 발생한 오류입니다.

별도로 처리하지 않아 현재 빌드 불가능 상태입니다. 이후 Bookmark 기능 붙일 때 수정 후 확인 필요합니다.

```
Type '{ id: number; name: string; category: string; coordinates: { lat: number; lng: number; }; visited: number; isContinue: boolean; }' is not assignable to type '{ id: string; category: string; name: string; visited: number; }'.
  Types of property 'id' are incompatible.
    Type 'number' is not assignable to type 'string'.
```

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
