### PR TITLE
feat: 사용자 인증확인 컴포넌트 구현

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,9 +1,9 @@
 import {
-    CheckEmailApiParams,
-    CheckEmailApiResponse,
-    LoginApiDatas,
-    SignupApiDatas,
-    AuthApiResonse,
+	CheckEmailApiParams,
+	CheckEmailApiResponse,
+	LoginApiDatas,
+	SignupApiDatas,
+	AuthApiResonse,
 } from '../types/auth';
 import { http } from './apiClient';
 
@@ -11,7 +11,7 @@ import { http } from './apiClient';
  * @param email 이메일
  */
 export const checkEmail = async (email: string): Promise<CheckEmailApiResponse> =>
-    await http.get<CheckEmailApiResponse, CheckEmailApiParams>(`/auth/check-email`, { email });
+	await http.get<CheckEmailApiResponse, CheckEmailApiParams>(`/auth/check-email`, { email });
 
 /**
  * @param email 이메일
@@ -19,11 +19,16 @@ export const checkEmail = async (email: string): Promise<CheckEmailApiResponse> 
  * @param nickname 닉네임
  */
 export const signup = async ({ email, password, nickname }: SignupApiDatas): Promise<AuthApiResonse> =>
-    await http.post<AuthApiResonse, SignupApiDatas>(`/auth/register`, { email, password, nickname });
+	await http.post<AuthApiResonse, SignupApiDatas>(`/auth/register`, { email, password, nickname });
 
 /**
  * @param email 이메일
  * @param password 비밀번호
  */
 export const login = async ({ email, password }: LoginApiDatas): Promise<AuthApiResonse> =>
-    await http.post<AuthApiResonse, LoginApiDatas>(`/auth/login`, { email, password });
+	await http.post<AuthApiResonse, LoginApiDatas>(`/auth/login`, { email, password });
+
+/**
+ * 로그인 확인
+ */
+export const getAuthValidation = async (): Promise<AuthApiResonse> => await http.get<AuthApiResonse>('/auth/valid');

--- a/src/components/routeGuards/AuthGuard.tsx
+++ b/src/components/routeGuards/AuthGuard.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import useUserStore from '../../store/userStore';
+import useFadeNavigate from '../../hooks/useFadeNavigate';
+import { Outlet } from 'react-router-dom';
+import useAuthValidation from '../../hooks/useAuthValidation';
+
+export default function AuthGaurd(): React.ReactElement {
+	const { setUser, user } = useUserStore();
+	const navigate = useFadeNavigate();
+	const { data, isLoading } = useAuthValidation();
+
+	useEffect(() => {
+		if (!user) {
+			if (!isLoading) {
+				if (data?.user) {
+					setUser(data.user);
+				} else {
+					navigate('/login');
+				}
+			}
+		}
+	}, [isLoading, user, navigate, setUser, data?.user]);
+
+	return <Outlet />;
+}

--- a/src/components/routeGuards/MainGuard.tsx
+++ b/src/components/routeGuards/MainGuard.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import useUserStore from '../../store/userStore';
+import useFadeNavigate from '../../hooks/useFadeNavigate';
+import MainPage from '../../pages/MainPage';
+import useAuthValidation from '../../hooks/useAuthValidation';
+
+export default function MainGuard(): React.ReactElement {
+	const { setUser, user } = useUserStore();
+	const navigate = useFadeNavigate();
+	const { data, isLoading } = useAuthValidation();
+
+	useEffect(() => {
+		if (!user) {
+			if (!isLoading) {
+				if (data?.user) {
+					setUser(data.user);
+					navigate('/map');
+				}
+			}
+		}
+	}, [isLoading, user, navigate, setUser, data?.user]);
+
+	return <MainPage />;
+}

--- a/src/components/routeGuards/RoleGuard.tsx
+++ b/src/components/routeGuards/RoleGuard.tsx
@@ -1,0 +1,22 @@
+import { Outlet } from 'react-router-dom';
+import useUserStore from '../../store/userStore';
+import useFadeNavigate from '../../hooks/useFadeNavigate';
+import { useEffect } from 'react';
+
+interface RoleGuardProps {
+	requiredRole: string;
+	redirectUrl: string;
+}
+
+export default function RoleGuard({ requiredRole, redirectUrl }: RoleGuardProps): React.ReactElement {
+	const { user } = useUserStore();
+	const navigate = useFadeNavigate();
+
+	useEffect(() => {
+		if (user && user.role !== requiredRole) {
+			navigate(redirectUrl);
+		}
+	}, [user, requiredRole, navigate, redirectUrl]);
+
+	return <Outlet />;
+}

--- a/src/hooks/useAuthValidation.ts
+++ b/src/hooks/useAuthValidation.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAuthValidation } from '../apis/auth';
+
+export default function useAuthValidation() {
+	const { data, isLoading } = useQuery({
+		queryKey: ['user'],
+		queryFn: getAuthValidation,
+		staleTime: 30 * 60 * 60,
+		refetchInterval: 30 * 60 * 60,
+	});
+
+	return { data, isLoading };
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,128 +3,130 @@ import { Controller, useForm } from 'react-hook-form';
 import useFadeNavigate from '../hooks/useFadeNavigate.ts';
 import KakaoIcon from '../assets/images/kakao.svg?react';
 import { login } from '../apis/auth.ts';
+import useUserStore from '../store/userStore.ts';
 
 interface LoginFormData {
-    email: string;
-    password: string;
+	email: string;
+	password: string;
 }
 
 export default function LoginPage() {
-    const navigate = useFadeNavigate();
+	const navigate = useFadeNavigate();
+	const { setUser } = useUserStore();
 
-    const { control, handleSubmit, reset } = useForm<LoginFormData>({
-        defaultValues: {
-            email: '',
-            password: '',
-        },
-    });
+	const { control, handleSubmit, reset } = useForm<LoginFormData>({
+		defaultValues: {
+			email: '',
+			password: '',
+		},
+	});
 
-    const onSubmit = async ({ email, password }: LoginFormData) => {
-        const response = await login({ email, password });
+	const onSubmit = async ({ email, password }: LoginFormData) => {
+		const response = await login({ email, password });
 
-        if (response.msg === 'ok') {
-            reset(); //form reset
+		if (response.msg === 'ok') {
+			reset(); //form reset
+			setUser(response.user);
+			//map으로 이동
+			navigate(`/map`);
 
-            //map으로 이동
-            navigate(`/map`);
+			//회원정보를 zustand에 저장?해야됬었나..?
+		}
+	};
 
-            //회원정보를 zustand에 저장?해야됬었나..?
-        }
-    };
+	return (
+		<div className='bg-black h-full flex flex-col justify-center items-center py-11'>
+			<div className='w-full flex justify-center flex-col items-center flex-1'>
+				<p className='text-3xl font-point text-white py-11 tracking-tighter'>로그인</p>
+				<form className='max-w-screen-sm w-full flex flex-col gap-16 sm:gap-24 py-11'>
+					<div className='flex flex-col gap-8'>
+						<Controller
+							name='email'
+							control={control}
+							rules={{
+								required: '이메일은 필수 입력 항목입니다.',
+								pattern: {
+									value: /^\S+@\S+$/i,
+									message: '잘못된 이메일 형식입니다.',
+								},
+							}}
+							render={({ field: { onChange, value, name }, fieldState: { invalid }, formState }) => (
+								<div className='relative'>
+									<Input
+										name={name}
+										value={value}
+										onChange={onChange}
+										id='email'
+										label='이메일'
+										type='text'
+										placeholder='example@gmail.com'
+									/>
+									{invalid && (
+										<p className='absolute top-full left-[50px] sm:left-[100px] text-primary text-xs py-1'>
+											{formState.errors.email?.message}
+										</p>
+									)}
+								</div>
+							)}
+						/>
+						<Controller
+							name='password'
+							control={control}
+							rules={{
+								required: '비밀번호는 필수 입력 항목입니다.',
+								pattern: {
+									value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,20}$/,
+									message: '영문, 숫자, 특수문자 포함 8 ~ 20자로 입력해주세요.',
+								},
+							}}
+							render={({ field: { onChange, value, name }, fieldState: { invalid }, formState }) => (
+								<div className='relative'>
+									<Input
+										name={name}
+										value={value}
+										onChange={onChange}
+										id='password'
+										label='비밀번호'
+										type='password'
+										placeholder='**********'
+									/>
 
-    return (
-        <div className="bg-black h-full flex flex-col justify-center items-center py-11">
-            <div className="w-full flex justify-center flex-col items-center flex-1">
-                <p className="text-3xl font-point text-white py-11 tracking-tighter">로그인</p>
-                <form className="max-w-screen-sm w-full flex flex-col gap-16 sm:gap-24 py-11">
-                    <div className="flex flex-col gap-8">
-                        <Controller
-                            name="email"
-                            control={control}
-                            rules={{
-                                required: '이메일은 필수 입력 항목입니다.',
-                                pattern: {
-                                    value: /^\S+@\S+$/i,
-                                    message: '잘못된 이메일 형식입니다.',
-                                },
-                            }}
-                            render={({ field: { onChange, value, name }, fieldState: { invalid }, formState }) => (
-                                <div className="relative">
-                                    <Input
-                                        name={name}
-                                        value={value}
-                                        onChange={onChange}
-                                        id="email"
-                                        label="이메일"
-                                        type="text"
-                                        placeholder="example@gmail.com"
-                                    />
-                                    {invalid && (
-                                        <p className="absolute top-full left-[50px] sm:left-[100px] text-primary text-xs py-1">
-                                            {formState.errors.email?.message}
-                                        </p>
-                                    )}
-                                </div>
-                            )}
-                        />
-                        <Controller
-                            name="password"
-                            control={control}
-                            rules={{
-                                required: '비밀번호는 필수 입력 항목입니다.',
-                                pattern: {
-                                    value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,20}$/,
-                                    message: '영문, 숫자, 특수문자 포함 8 ~ 20자로 입력해주세요.',
-                                },
-                            }}
-                            render={({ field: { onChange, value, name }, fieldState: { invalid }, formState }) => (
-                                <div className="relative">
-                                    <Input
-                                        name={name}
-                                        value={value}
-                                        onChange={onChange}
-                                        id="password"
-                                        label="비밀번호"
-                                        type="password"
-                                        placeholder="**********"
-                                    />
-
-                                    {invalid && (
-                                        <p className="absolute top-full left-[50px] sm:left-[100px] text-primary text-xs py-1">
-                                            {formState.errors.password?.message}
-                                        </p>
-                                    )}
-                                </div>
-                            )}
-                        />
-                    </div>
-                </form>
-            </div>
-            <div className="flex flex-col justify-center gap-2 items-center mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-320px)] pb-11">
-                <button
-                    className="bg-primary py-5 text-white rounded-lg font-bold w-full tracking-tighter"
-                    onClick={handleSubmit(onSubmit)}
-                >
-                    로그인
-                </button>
-                <p className="text-white text-xs py-2 line-text">또는</p>
-                <button
-                    type="button"
-                    className="mb-4 bg-kakao tracking-tighter text-kakao-black py-5 rounded-lg font-bold relative w-full"
-                >
-                    <KakaoIcon className="absolute left-4 top-1/2 -translate-y-1/2" width={24} height={24} />
-                    카카오 로그인
-                </button>
-                <p className="text-white tracking-tighter">
-                    계정이 없으신가요?{' '}
-                    <strong
-                        className="text-primary font-bold cursor-pointer tracking-tighter"
-                        onClick={() => navigate('/signup')}
-                    >
-                        가입하기
-                    </strong>
-                </p>
-            </div>
-        </div>
-    );
+									{invalid && (
+										<p className='absolute top-full left-[50px] sm:left-[100px] text-primary text-xs py-1'>
+											{formState.errors.password?.message}
+										</p>
+									)}
+								</div>
+							)}
+						/>
+					</div>
+				</form>
+			</div>
+			<div className='flex flex-col justify-center gap-2 items-center mx-auto w-[calc(100%-100px)] sm:w-[calc(100%-320px)] pb-11'>
+				<button
+					className='bg-primary py-5 text-white rounded-lg font-bold w-full tracking-tighter'
+					onClick={handleSubmit(onSubmit)}
+				>
+					로그인
+				</button>
+				<p className='text-white text-xs py-2 line-text'>또는</p>
+				<button
+					type='button'
+					className='mb-4 bg-kakao tracking-tighter text-kakao-black py-5 rounded-lg font-bold relative w-full'
+				>
+					<KakaoIcon className='absolute left-4 top-1/2 -translate-y-1/2' width={24} height={24} />
+					카카오 로그인
+				</button>
+				<p className='text-white tracking-tighter'>
+					계정이 없으신가요?{' '}
+					<strong
+						className='text-primary font-bold cursor-pointer tracking-tighter'
+						onClick={() => navigate('/signup')}
+					>
+						가입하기
+					</strong>
+				</p>
+			</div>
+		</div>
+	);
 }

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { IUser } from '../types/auth';
+
+interface UserState {
+	user: IUser | null;
+	setUser: (newUser: IUser) => void;
+}
+
+const useUserStore = create<UserState>((set) => ({
+	user: null,
+	setUser: (newUser) => set({ user: newUser }),
+}));
+
+export default useUserStore;

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,30 +1,32 @@
 import { BaseApiResponse } from './response';
 
+export interface IUser {
+	_id: string;
+	nickname: string;
+	role: string;
+}
+
 interface CheckEmailApiResponse extends BaseApiResponse {
-    isAble: boolean;
+	isAble: boolean;
 }
 
 interface CheckEmailApiParams {
-    email: string;
+	email: string;
 }
 
 interface AuthApiResonse extends BaseApiResponse {
-    user: {
-        _id: string;
-        nickname: string;
-        role: string;
-    };
+	user: IUser;
 }
 
 interface SignupApiDatas {
-    email: string;
-    password: string;
-    nickname: string;
+	email: string;
+	password: string;
+	nickname: string;
 }
 
 interface LoginApiDatas {
-    email: string;
-    password: string;
+	email: string;
+	password: string;
 }
 
 export type { CheckEmailApiResponse, CheckEmailApiParams, AuthApiResonse, SignupApiDatas, LoginApiDatas };


### PR DESCRIPTION
## 📌 과제 설명
- user 정보 전역 상태관리 스토어 작성 (useUserStoe)
- 토큰 기반 사용자 인증을 위한 인증 확인 API 연동 로직 구현
- 사용자 인증 확인 컴포넌트작성
  - MainGuard
  최초 접속시 사용자 토큰을 기반으로 로그인 가능 유저인지 판단(가능: '/map'으로 리다이렉트, 불가: homePage 리다이렉트)
  - AuthGuard
  사용자 정보가 전역에 없을 시 토큰을 기반으로 로그인 가능 유저인지 판단(가능: 하위 컴포넌트, 불가: /login 리다이렉트)

## 👩‍💻 요구 사항과 구현 내용

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점

Closes #157