### PR TITLE
feat: 댓글 작성 / 삭제 연동 및 Detail페이지 수정

### DIFF
--- a/src/apis/comment.ts
+++ b/src/apis/comment.ts
@@ -32,6 +32,5 @@ export const postComment = async ({
   });
 
 // 댓글 삭제
-export const deleteComment = async ({ commentId }: DeleteCommentApiParams) => {
+export const deleteComment = async ({ commentId }: DeleteCommentApiParams) =>
   await http.delete<BaseApiResponse>(`/comment/${commentId}`);
-};

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,11 +1,14 @@
 import { toast } from "react-toastify";
 import { deleteComment } from "../apis/comment.ts";
 import useUserStore from "../store/userStore.ts";
+import useComment from "../hooks/useComment.ts";
 import Delete from "../assets/images/delete.svg?react";
 
 interface CommentProps {
   id: string;
   authorId: string;
+  // 댓글 삭제 시 refetch를 보낼 target Id ({storeId} | 'me')
+  targetId: string;
   name: string;
   content: string;
   createdAt: string;
@@ -14,16 +17,20 @@ interface CommentProps {
 export default function Comment({
   id,
   authorId,
+  targetId,
   name,
   createdAt,
   content,
 }: CommentProps) {
   const { user } = useUserStore();
+  const { refetch } = useComment(targetId);
 
   const handleDeleteComment = () => {
     deleteComment({ commentId: id }).then((data) => {
       if (data.msg === "ok") {
-        toast.success("삭제되었습니다.");
+        refetch().then(() => {
+          toast.success("삭제되었습니다.");
+        });
       } else {
         toast.error(data.msg);
       }

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,7 +1,10 @@
-import Delete from "../assets/images/delete.svg?react";
+import { toast } from "react-toastify";
+import { deleteComment } from "../apis/comment.ts";
 import useUserStore from "../store/userStore.ts";
+import Delete from "../assets/images/delete.svg?react";
 
 interface CommentProps {
+  id: string;
   authorId: string;
   name: string;
   content: string;
@@ -9,12 +12,23 @@ interface CommentProps {
 }
 
 export default function Comment({
+  id,
   authorId,
   name,
   createdAt,
   content,
 }: CommentProps) {
   const { user } = useUserStore();
+
+  const handleDeleteComment = () => {
+    deleteComment({ commentId: id }).then((data) => {
+      if (data.msg === "ok") {
+        toast.success("삭제되었습니다.");
+      } else {
+        toast.error(data.msg);
+      }
+    });
+  };
 
   return (
     <div className="bg-white tracking-tighter border-b-1 border-comment">
@@ -23,7 +37,7 @@ export default function Comment({
         <div className="flex gap-x-2 align-middle">
           <div className="text-category">{createdAt}</div>
           {user?._id === authorId && (
-            <button>
+            <button onClick={handleDeleteComment}>
               <Delete width={15} height={15} />
             </button>
           )}

--- a/src/components/WriteReview.tsx
+++ b/src/components/WriteReview.tsx
@@ -1,17 +1,39 @@
-import Edit from '../assets/images/edit.svg?react';
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { postComment } from "../apis/comment.ts";
+import Edit from "../assets/images/edit.svg?react";
 
 export default function WriteReview() {
-    return (
-        <div className="border-t-1 bottom-0 w-full sticky z-2 bg-white border-comment">
-            <div className="w-[calc(100%-140px)] sm:w-[calc(100%-240px)] mx-auto pt-3 pb-8 flex gap-x-5">
-                <textarea
-                    className="w-full pt-3 px-3 outline-none border-1 border-comment rounded-lg bg-form tracking-tighter resize-none"
-                    placeholder="리뷰를 작성해주세요"
-                />
-                <button>
-                    <Edit width={30} height={30} />
-                </button>
-            </div>
-        </div>
-    );
+  const { id: storeId } = useParams<{ id: string }>();
+  const [content, setContent] = useState("");
+
+  const handlePostComment = () => {
+    if (content.trim() === "") {
+      toast.error("리뷰 내용을 작성해주세요.");
+      return;
+    }
+    if (storeId) {
+      postComment({ content, storeId }).then(() => {
+        toast.success("리뷰가 등록되었습니다.");
+        setContent("");
+      });
+    }
+  };
+
+  return (
+    <div className="border-t-1 bottom-0 w-full sticky z-2 bg-white border-comment">
+      <div className="w-[calc(100%-140px)] sm:w-[calc(100%-240px)] mx-auto pt-3 pb-8 flex gap-x-5">
+        <textarea
+          className="w-full pt-3 px-3 outline-none border-1 border-comment rounded-lg bg-form tracking-tighter resize-none"
+          placeholder="리뷰를 작성해주세요"
+          value={content}
+          onChange={({ target }) => setContent(target.value)}
+        />
+        <button onClick={handlePostComment}>
+          <Edit width={30} height={30} />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/WriteReview.tsx
+++ b/src/components/WriteReview.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { postComment } from "../apis/comment.ts";
+import useComment from "../hooks/useComment.ts";
 import Edit from "../assets/images/edit.svg?react";
 
 export default function WriteReview() {
   const { id: storeId } = useParams<{ id: string }>();
+  const { refetch } = useComment(storeId!);
   const [content, setContent] = useState("");
 
   const handlePostComment = () => {
@@ -15,8 +17,10 @@ export default function WriteReview() {
     }
     if (storeId) {
       postComment({ content, storeId }).then(() => {
-        toast.success("리뷰가 등록되었습니다.");
-        setContent("");
+        refetch().then(() => {
+          toast.success("리뷰가 등록되었습니다.");
+          setContent("");
+        });
       });
     }
   };

--- a/src/hooks/useComment.ts
+++ b/src/hooks/useComment.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { getComment, getMyComment } from "../apis/comment.ts";
+import type {
+  CommentApiResponse,
+  MyCommentApiResponse,
+} from "../types/comment";
+
+const getComments = (
+  target: string,
+): Promise<MyCommentApiResponse | CommentApiResponse> =>
+  target === "me" ? getMyComment() : getComment({ storeId: target });
+
+/**
+ * 댓글 목록
+ * @param target 댓글을 가져올 대상 ('me' | {storeId})
+ */
+export default function useComment<T>(target: "me" | string) {
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["comment", target],
+    queryFn: () => getComments(target),
+    select: (data) => ({ comments: data.comments as T[] }),
+  });
+
+  return { data, isLoading, refetch };
+}

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -104,6 +104,7 @@ export default function DetailPage() {
             {comments.map((comment) => (
               <Comment
                 key={`comment_${comment._id}`}
+                id={comment._id}
                 name={comment.authorId.nickname}
                 authorId={comment.authorId._id}
                 createdAt={comment.createdAt}

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -93,7 +93,7 @@ export default function DetailPage() {
               {storeInfo.category}
             </div>
           </div>
-          <Button />
+          <Button defaultValue={storeInfo.paymentMethod} disabled />
         </div>
         <div className="w-[calc(100%-140px)] sm:w-[calc(100%-240px)] flex justify-start items-center gap-x-1 text-base mx-auto mb-3 pt-11">
           <MessageSquare width={16} height={16} />


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

댓글 작성 / 삭제 연동 및 Detail페이지 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

![image](https://github.com/user-attachments/assets/258fcdff-71db-439a-b399-90023e91d36b)
![image](https://github.com/user-attachments/assets/33eb327c-0d7f-4e6c-828e-f23e08b65832)

1. 댓글 작성 / 삭제
    - 댓글 작성 / 삭제 기능을 구현했습니다.
    - Comment 컴포넌트에 id(commentId), targetId(삭제 시 refetch에 사용될 id => `me` | `{storeId}`) props가 추가되었습니다. **Comment를 사용하는 MyPage, MyTruckPage에 해당 속성 추가가 필요**합니다. (현재 해당 부분때문에 build 오류 발생중입니다.)
2. Detail 페이지 수정
    - Button 컴포넌트의 defaultValue / disabled를 적용했습니다. 

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
