### PR TITLE
fix: TobBar z-index & 내 가게 페이지 버튼 수정

### DIFF
--- a/src/components/EditStore.tsx
+++ b/src/components/EditStore.tsx
@@ -21,13 +21,13 @@ export default function EditStore() {
     <div className="border-t-1 bg-white border-comment">
       <div className="w-[calc(100%-80px)] sm:w-[calc(100%-250px)] mx-auto pt-5 pb-5 flex gap-x-5">
         <button
-          className="bg-secondary flex-1 p-5 rounded-lg tracking-tighter font-semibold"
+          className="bg-secondary flex-1 py-5 rounded-lg tracking-tighter font-semibold"
           onClick={() => navigate(`/register`, { replace: true })}
         >
           내 가게 수정하기
         </button>
         <button
-          className="border-1 border-placeholder text-placeholder flex-1 p-5 rounded-lg tracking-tighter font-semibold"
+          className="border-1 border-placeholder text-placeholder flex-1 py-5 rounded-lg tracking-tighter font-semibold"
           onClick={handleDeleteStore}
         >
           가게 삭제하기

--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -20,7 +20,7 @@ export default function TopBar({ title }: TopBarProps) {
 
   return (
     <>
-      <div className="flex w-full bg-primary justify-center items-center px-4 py-5 sticky top-0 z-10">
+      <div className="flex w-full bg-primary justify-center items-center px-4 py-5 sticky top-0 z-20">
         <div className="w-[calc(100%-50px)] sm:w-[calc(100%-100px)] flex items-center">
           <div className="flex-1 flex items-center">
             {(pathname === "/detail" || pathname === `/my-truck`) && (


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

TobBar z-index 및 내 가게 페이지 버튼 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/1d3b0ed3-2184-4aef-b5da-e37c61112a41) | ![image](https://github.com/user-attachments/assets/9c6c99bd-d98c-4d18-b260-f198be99c7c2) |

1. TobBar z-index를 `z-10` => `z-20`으로 변경했습니다.
2. EditStore 컴포넌트 내의 버튼의 padding을 `p-5`에서 `py-5`로 변경했습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
