### PR TITLE
feat: UserStore 수정

### DIFF
--- a/src/components/EditStore.tsx
+++ b/src/components/EditStore.tsx
@@ -2,15 +2,18 @@ import { toast } from "react-toastify";
 import { deleteStore } from "../apis/store.ts";
 import useFadeNavigate from "../hooks/useFadeNavigate.ts";
 import useMyStore from "../hooks/useMyStore.ts";
+import useUserStore from "../store/userStore.ts";
 
 export default function EditStore() {
   const navigate = useFadeNavigate();
   const { refetch } = useMyStore();
+  const { setRole } = useUserStore();
 
   const handleDeleteStore = () => {
     deleteStore().then((data) => {
       if (data.msg === "ok") {
         refetch().then(() => {
+          setRole("user");
           toast.success("정상적으로 삭제되었습니다.");
         });
       }

--- a/src/components/register/RegisterButton.tsx
+++ b/src/components/register/RegisterButton.tsx
@@ -2,6 +2,7 @@ import { toast } from "react-toastify";
 import { postStore } from "../../apis/store";
 import useFadeNavigate from "../../hooks/useFadeNavigate";
 import useMyStore from "../../hooks/useMyStore.ts";
+import useUserStore from "../../store/userStore.ts";
 
 interface RegisterButtonProps {
   // 식당(트럭_) 이름
@@ -28,6 +29,7 @@ export default function RegisterButton({
 }: RegisterButtonProps) {
   const navigate = useFadeNavigate();
   const { refetch } = useMyStore();
+  const { setRole } = useUserStore();
 
   const submitHandler = async () => {
     // 값이 비어 있는지 검사
@@ -56,6 +58,7 @@ export default function RegisterButton({
 
     if (res.msg === "ok") {
       refetch().then(() => {
+        setRole("owner");
         navigate(`/my-truck`, { replace: true });
         toast.success("저장되었습니다.");
       });

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,14 +1,20 @@
-import { create } from 'zustand';
-import { IUser } from '../types/auth';
+import { create } from "zustand";
+import { IUser } from "../types/auth";
 
 interface UserState {
-	user: IUser | null;
-	setUser: (newUser: IUser | null) => void;
+  user: IUser | null;
+  setUser: (newUser: IUser | null) => void;
+  setNickname: (nickname: string) => void;
+  setRole: (role: "owner" | "user") => void;
 }
 
 const useUserStore = create<UserState>((set) => ({
-	user: null,
-	setUser: (newUser) => set({ user: newUser }),
+  user: null,
+  setUser: (newUser) => set({ user: newUser }),
+  setNickname: (nickname) =>
+    set((state) => ({ user: state.user ? { ...state.user, nickname } : null })), //get().setUser({ ...get().user, nickname }),
+  setRole: (role) =>
+    set((state) => ({ user: state.user ? { ...state.user, role } : null })), //get().setUser({ ...get().user, role }),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

UserStore 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- setNickname / setRole 추가
- setRole이 적용되어야하는 부분은 다 적용했습니다.

### MyPage 수정 부분

1. useUserStore 호출하는 부분에 `setNickname: setUserNickname` 추가
    `const { user: userInfo, setUser, setNickname: setUserNickname } = useUserStore();`
    - 이미 setNickname(nickname input의 setValue)이 존재하기 때문에 setUserNickname으로 받아옵니다.
2. editNickname 함수 호출 이후 ` setUserNickname(nickname)` 추가
    ```ts
    editNickname({ nickname }).then(() => {
      setUserNickname(nickname);
      toast.success("변경이 완료되었습니다.");
      setIsEditMode(false);
    });
    ```
    - 닉네임 변경 함수가 완료됐을 때 `setUserNickname(nickname)`을 사용해 userInfo의 nickname을 변경합니다.


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
