### PR TITLE
refactor: 북마크 로직 분리 및 오류 수정

### DIFF
--- a/src/components/BookMarkButton.tsx
+++ b/src/components/BookMarkButton.tsx
@@ -1,18 +1,54 @@
 import StarIcon from "../assets/images/star.svg?react";
+import { useEffect, useState } from "react";
+import { postBookmark } from "../apis/bookmark.ts";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import useFetchBookmark from "../hooks/useFetchBookmark.ts";
 
 interface BookMarkButtonProps {
-  isBookmarked: boolean;
-  onClick: () => void;
+  onClick?: () => void;
+  storeId?: string;
   size?: number;
 }
 
 export default function BookMarkButton({
-  isBookmarked,
-  onClick,
+  storeId,
   size = 20,
 }: BookMarkButtonProps) {
+  const { id } = useParams<{ id: string }>();
+  const _storeId = storeId || id || "";
+  const { bookmarks, refetch } = useFetchBookmark();
+  const [isBookmarked, setIsBookmarked] = useState(false);
+
+  useEffect(() => {
+    if (_storeId) {
+      setIsBookmarked(
+        !!bookmarks.find((bookmark) => bookmark.storeId === _storeId),
+      );
+    }
+  }, []);
+
+  // 북마크 post 함수 (등록/삭제)
+  const handleBookmarkButtonClick = () => {
+    if (_storeId) {
+      postBookmark({ storeId: _storeId })
+        .then((data) => {
+          setIsBookmarked((prev) => !prev); // 로컬 상태 업데이트
+          refetch(); // 리스트 호출
+          return data.bookmark;
+        })
+        .then((isBookmarked) => {
+          if (isBookmarked) {
+            toast.success("북마크에 추가되었습니다.");
+          } else {
+            toast.success("북마크에 삭제되었습니다.");
+          }
+        });
+    }
+  };
+
   return (
-    <div onClick={onClick} className="relative">
+    <div onClick={handleBookmarkButtonClick} className="relative">
       <StarIcon
         width={size}
         height={size}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,10 +1,7 @@
-import { useState, useEffect } from "react";
 import BookMarkButton from "./BookMarkButton";
 import useFadeNavigate from "../hooks/useFadeNavigate.ts";
 import { categoryImages } from "../assets/images/category";
 import { categories } from "../constants/categories.ts";
-import { postBookmark, getBookmark } from "../apis/bookmark.ts";
-import { toast } from "react-toastify";
 
 interface CardProps {
   info: {
@@ -16,76 +13,15 @@ interface CardProps {
     isOpen: boolean;
   };
   bg: string;
-
-  onBookmarkToggle?: (storeId: string, isBookmarked: boolean) => void; // 토글 시 부모에게 알림
 }
 
-interface BookmarkItem {
-  id?: string;
-  comments: number;
-  name: string;
-  isOpen: boolean;
-  category: string;
-  storeId: string;
-}
-
-export default function Card({
-  info,
-  bg = "black",
-  onBookmarkToggle,
-}: CardProps) {
+export default function Card({ info, bg = "black" }: CardProps) {
   const visitOrComments = info.visited ?? info.comments ?? 0; // 방문자 수
   const navigate = useFadeNavigate();
   const ImgComponent =
     // 이후 categoryImages[info.category].component 로 수정 필요
     categoryImages[categories.includes(info.category) ? info.category : "기타"]
       .component;
-
-  const [bookmark, setBookmark] = useState<BookmarkItem[]>([]);
-  const [isBookmarked, setIsBookMarked] = useState<boolean>(false);
-
-  // get 모든 북마크 데이터 저장
-  useEffect(() => {
-    const getBookmarkData = async () => {
-      const res = await getBookmark();
-
-      setBookmark(res.bookmarks as BookmarkItem[]);
-    };
-
-    getBookmarkData();
-  }, []);
-
-  // 북마크 여부에 따라 별 반응 (색 채우고, 안 채우고)
-  useEffect(() => {
-    const checkIfBookmarked = () => {
-      if (bookmark) {
-        const matched = bookmark.some(
-          (place) => place.storeId === info.storeId,
-        );
-
-        setIsBookMarked(matched);
-      }
-    };
-
-    checkIfBookmarked();
-  }, [bookmark, info]);
-
-  // 북마크 post 함수 (등록/삭제)
-  const handleBookmarkToggle = async (storeId: string) => {
-    await postBookmark({ storeId });
-    const updatedBookmarks = await getBookmark(); // 북마크 상태 최신화
-    setBookmark(updatedBookmarks.bookmarks as BookmarkItem[]); // bookmark 상태 업데이트
-
-    setIsBookMarked((prev) => !prev); // 로컬 상태 업데이트
-    if (onBookmarkToggle) {
-      onBookmarkToggle(info.storeId, !isBookmarked); // onBookmarkToggle이 있을 때만 호출
-      toast.success("북마크에서 삭제되었습니다.");
-    } else if (isBookmarked) {
-      toast.success("북마크에 삭제되었습니다.");
-    } else {
-      toast.success("북마크에 추가되었습니다.");
-    }
-  };
 
   return (
     <div
@@ -114,8 +50,8 @@ export default function Card({
         <div className="flex-1 flex flex-col gap-y-2 pt-2">
           <div className="flex justify-end">
             <BookMarkButton
-              isBookmarked={isBookmarked}
-              onClick={() => handleBookmarkToggle(info.storeId)}
+              storeId={info.storeId}
+              // onClick={() => handleBookmarkToggle(info.storeId)}
               size={30}
             />
           </div>

--- a/src/hooks/useFetchBookmark.ts
+++ b/src/hooks/useFetchBookmark.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getBookmark } from "../apis/bookmark.ts";
+import type { BookmarkListApiResponse } from "../types/bookmark";
+
+export default function useFetchBookmark() {
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["bookmark"],
+    queryFn: getBookmark,
+    select: (data: BookmarkListApiResponse) => data.bookmarks,
+  });
+
+  return {
+    bookmarks: data || [],
+    isLoading,
+    refetch,
+  };
+}

--- a/src/hooks/useFetchStores.ts
+++ b/src/hooks/useFetchStores.ts
@@ -12,5 +12,5 @@ export default function useFetchStores() {
     refetchInterval: 1000 * 60, // 1분?
   });
 
-  return { data, isLoading, refetch };
+  return { stores: data || [], isLoading, refetch };
 }

--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -37,13 +37,7 @@ export default function TopBar({ title }: TopBarProps) {
             {title}
           </p>
           <div className="flex-1 flex items-center justify-end">
-            {pathname === "/detail" && (
-              <BookMarkButton
-                isBookmarked={false}
-                onClick={() => {}}
-                size={30}
-              />
-            )}
+            {pathname === "/detail" && <BookMarkButton size={30} />}
           </div>
         </div>
       </div>

--- a/src/pages/BookMarkPage.tsx
+++ b/src/pages/BookMarkPage.tsx
@@ -1,67 +1,43 @@
-import { useState, useEffect } from "react";
-import { getBookmark } from "../apis/bookmark";
+import { useEffect } from "react";
 import useTitleStore from "../store/titleStore";
 import useNotificationStore from "../store/notificationStore.ts";
+import useFetchBookmark from "../hooks/useFetchBookmark.ts";
 import Card from "../components/Card";
-import Heart from "../assets/images/heart.svg?react";
 import NoBookMark from "../components/bookmark/NoBookMark";
-
-// _id는 북마크 아이디
-// storeId는 스토어 아이디
-interface BookmarkItem {
-  id: string;
-  storeId: string;
-  comments: number;
-  name: string;
-  isOpen: boolean;
-  category: string;
-}
+import Heart from "../assets/images/heart.svg?react";
 
 export default function BookMarkPage() {
   const setTitle = useTitleStore((state) => state.setTitle);
   const { notificationList } = useNotificationStore();
-  const [bookmark, setBookmark] = useState<BookmarkItem[]>([]);
+  const { bookmarks, refetch } = useFetchBookmark();
 
   useEffect(() => {
     setTitle("북마크");
   }, []);
 
-  // get 모든 북마크 데이터 저장
+  // 알림 발생하면 refetch
   useEffect(() => {
-    const getBookmarkData = async () => {
-      const res = await getBookmark();
-
-      setBookmark(res.bookmarks as BookmarkItem[]);
-    };
-
-    getBookmarkData();
+    refetch();
   }, [notificationList]);
-
-  // 북마크 상태 업데이트 함수
-  const handleBookmarkToggle = (storeId: string) => {
-    setBookmark((prev) => {
-      return prev.filter((item) => item.storeId !== storeId); // 기존 북마크 삭제
-    });
-  };
 
   return (
     <>
-      {bookmark.length >= 1 ? (
+      {bookmarks.length >= 1 ? (
         <div className="flex py-11 flex-col gap-y-8 mx-auto w-[calc(100%-50px)] sm:w-[calc(100%-230px)]">
           <p className="flex items-center">
             <Heart width={18} height={18} />
             <strong className="px-1 tracking-tight text-lg">
               나만의 푸드트럭
             </strong>
-            <strong className="text-primary text-lg">{bookmark.length}</strong>
+            <strong className="text-primary text-lg">{bookmarks.length}</strong>
             <span className="text-lg">개</span>
           </p>
-          {bookmark.map((data) => (
+          {bookmarks.map((data) => (
             <div key={data.name} className="flex flex-col">
               <Card
                 info={data}
                 bg="white"
-                onBookmarkToggle={handleBookmarkToggle}
+                // onBookmarkToggle={handleBookmarkToggle}
               />
             </div>
           ))}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -37,7 +37,7 @@ export default function MapPage() {
 
   const { user } = useUserStore();
   const { setLocation } = useStoresStore();
-  const { data: storeList = [], refetch } = useFetchStores();
+  const { stores, refetch } = useFetchStores();
 
   const mapRef = useRef<kakao.maps.Map | null>(null);
 
@@ -110,7 +110,7 @@ export default function MapPage() {
         onDragEnd={() => setIsMapMove(true)}
         onClick={() => setClickMarker(null)}
       >
-        {storeList.map((data) => (
+        {stores.map((data) => (
           <MapMarker
             key={`${data.name}-${data._id}`}
             // 나중에 임시데이터 지우면 data.category로 변경

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -17,10 +17,7 @@ import type { IStore } from "../types/store";
 
 type Coordinates = [longitude: number, latitude: number];
 
-export interface Marker extends IStore {
-  commentCount: number;
-  isContinue?: boolean;
-}
+type Marker = IStore & { commentCount: number };
 
 export default function MapPage() {
   const { lat, lon, setLocation: setMapLocation } = useMapLocationStore();
@@ -81,6 +78,17 @@ export default function MapPage() {
     }
   };
 
+  const handleClickMapMaker = (data: Marker) => {
+    new Promise((resolve) => {
+      if (clickMarker) {
+        setClickMarker(null);
+      }
+      return resolve("");
+    }).finally(() => {
+      setClickMarker(data);
+    });
+  };
+
   // 처음 로드될 때 내 위치로 이동
   useEffect(() => {
     if (!lon || !lat) {
@@ -119,9 +127,7 @@ export default function MapPage() {
             }
             coordinates={data.coordinates}
             title={data.name}
-            onClick={() => {
-              setClickMarker(data as Marker);
-            }}
+            onClick={() => handleClickMapMaker(data)}
           />
         ))}
 

--- a/src/types/bookmark.d.ts
+++ b/src/types/bookmark.d.ts
@@ -1,30 +1,38 @@
-import { BaseApiResponse } from './response';
+import { BaseApiResponse } from "./response";
 
 // GET	bookmark
 interface IBookmarkListItem {
-	name: string;
-	category: string;
-	isOpen: boolean;
-	comments: number;
+  _id: string;
+  storeId: string;
+  comments: number;
+  name: string;
+  isOpen: boolean;
+  category: string;
 }
 
 interface BookmarkListApiResponse extends BaseApiResponse {
-	bookmarks: IBookmarkListItem[];
+  bookmarks: IBookmarkListItem[];
 }
 
 // POST	bookmark
 interface IBookmark {
-	_id: string;
-	userId: string;
-	storeId: string;
+  _id: string;
+  userId: string;
+  storeId: string;
 }
 
 interface PostBookmarkApiParams {
-	storeId: string;
+  storeId: string;
 }
 
 interface PostBookmarkResponse extends BaseApiResponse {
-	bookmark: IBookmark;
+  bookmark: IBookmark;
 }
 
-export type { IBookmarkListItem, BookmarkListApiResponse, IBookmark, PostBookmarkApiParams, PostBookmarkResponse };
+export type {
+  IBookmarkListItem,
+  BookmarkListApiResponse,
+  IBookmark,
+  PostBookmarkApiParams,
+  PostBookmarkResponse,
+};


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

북마크 로직 분리 및 오류 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

### 북마크 로직 분리

BookmarkButton / BookmarkPage / Card 컴포넌트에 각각 있던 로직을 분리했습니다.

1. getComment 로직 => useFetchBookmark
2. postComment 로직 => BookmarkButton

#### 수정 내용

1. react-query를 사용해 Bookmark 데이터를 관리??하도록 수정했습니다.
2. BookmarkButton 컴포넌트에 storeId를 넘기거나 상세 페이지의 경우 path parameter의 storeId를 사용해 Bookmark 저장 로직을 구현했습니다.
3. 각각의 컴포넌트에서 사용되던 BookmarkItem 타입을 IBookmarkListItem이 사용되도록 수정했습니다.

### StoreList 수정

StoreList를 기존에 `data: storeList = []`로 불러왔었는데 이렇게 했을 때 storeList의 type이 any가 된다는 것을 확인했습니다. 그래서 **useStoresStore에서 넘겨줄 때 data에 값이 없다면 빈 배열을 넘기도록 수정**했습니다.

### Marker 클릭했을 때 발생한 오류 수정

Marker가 클릭된 상태로 다른 Marker 클릭 시 데이터가 제대로 적용되지 않던 오류가 있었습니다. 그래서 **clickMarker를 null로 만든 이후에 추가적으로 클릭된 marker가 적용되도록 수정**했습니다.

추가적으로 Marker의 타입을 IStore & { commentCount: number }으로 변경했습니다.

```ts
const handleClickMapMaker = (data: Marker) => {
  new Promise((resolve) => {
    if (clickMarker) {
      setClickMarker(null);
    }
    return resolve("");
  }).finally(() => {
    setClickMarker(data);
  });
};
```

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
