### PR TITLE
fix: 상세페이지에서 다시 지도로 넘어갈 때 어색하던 부분 수정

### DIFF
--- a/src/hooks/useFetchStores.ts
+++ b/src/hooks/useFetchStores.ts
@@ -10,6 +10,7 @@ export default function useFetchStores() {
     queryFn: () => getStoreList({ category, name, lat, lon }),
     select: (data: StoreListApiResponse) => data.stores,
     refetchInterval: 1000 * 60, // 1분?
+    staleTime: 1000 * 60 * 3,
   });
 
   return { stores: data || [], isLoading, refetch };

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,170 +1,194 @@
-import { useEffect, useRef, useState } from 'react';
-import { Map } from 'react-kakao-maps-sdk';
-import { useMyLocation } from '../hooks/useMyLocation';
-import useUserStore from '../store/userStore';
-import useStoresStore from '../store/storesStore';
-import useMapLocationStore from '../store/mapLocationStore.ts';
-import useNotificationStore from '../store/notificationStore.ts';
-import useFetchStores from '../hooks/useFetchStores';
-import Toggle from '../components/Toggle';
-import Search from '../components/map/Search';
-import MyLocation from '../components/map/MyLocation';
-import Card from '../components/Card';
-import MapMarker from '../components/map/MapMarker';
-import { categories } from '../constants/categories';
-import ReloadIcon from '../assets/images/reload.svg?react';
-import type { IStore } from '../types/store';
-import { toast } from 'react-toastify';
+import { useEffect, useRef, useState } from "react";
+import { Map } from "react-kakao-maps-sdk";
+import { useMyLocation } from "../hooks/useMyLocation";
+import useUserStore from "../store/userStore";
+import useStoresStore from "../store/storesStore";
+import useMapLocationStore from "../store/mapLocationStore.ts";
+import useNotificationStore from "../store/notificationStore.ts";
+import useFetchStores from "../hooks/useFetchStores";
+import Toggle from "../components/Toggle";
+import Search from "../components/map/Search";
+import MyLocation from "../components/map/MyLocation";
+import Card from "../components/Card";
+import MapMarker from "../components/map/MapMarker";
+import { categories } from "../constants/categories";
+import ReloadIcon from "../assets/images/reload.svg?react";
+import type { IStore } from "../types/store";
+import { toast } from "react-toastify";
 
 type Coordinates = [longitude: number, latitude: number];
 
 type Marker = IStore & { commentCount: number };
 
 export default function MapPage() {
-    const { lat, lon, setLocation: setMapLocation } = useMapLocationStore();
-    const { notificationList } = useNotificationStore();
+  const {
+    lat,
+    lon,
+    level,
+    setLocation: setMapLocation,
+    setZoom,
+  } = useMapLocationStore();
+  const { notificationList } = useNotificationStore();
 
-    // 맵 옮겼는지 여부
-    const [isMapMove, setIsMapMove] = useState(false);
+  // 맵 옮겼는지 여부
+  const [isMapMove, setIsMapMove] = useState(false);
 
-    // 마커 클릭 여부
-    const [clickMarker, setClickMarker] = useState<Marker | null>(null);
+  // 마커 클릭 여부
+  const [clickMarker, setClickMarker] = useState<Marker | null>(null);
 
-    // 초기 위치 설정
-    const [mapCenter, setMapCenter] = useState<Coordinates>([126.99581, 37.5563]);
+  // 초기 위치 설정
+  const [mapCenter, setMapCenter] = useState<Coordinates>([126.99581, 37.5563]);
 
-    const { user } = useUserStore();
-    const { setLocation } = useStoresStore();
-    const { stores, refetch, isLoading } = useFetchStores();
+  const { user } = useUserStore();
+  const { setLocation } = useStoresStore();
+  const { stores, refetch, isLoading } = useFetchStores();
 
-    const mapRef = useRef<kakao.maps.Map | null>(null);
+  const mapRef = useRef<kakao.maps.Map | null>(null);
 
-    // useMyLocation 훅으로 현재 위치 받아오는 함수
-    const { myLocation } = useMyLocation(({ latitude, longitude }) => {
-        setMapCenter([longitude, latitude]);
+  // useMyLocation 훅으로 현재 위치 받아오는 함수
+  const { myLocation } = useMyLocation(({ latitude, longitude }) => {
+    setMapCenter([longitude, latitude]);
+  });
+
+  const handleLocationChange = (coords: {
+    latitude: number;
+    longitude: number;
+  }) => {
+    setMapCenter([coords.longitude, coords.latitude]);
+    setMapLocation(coords.longitude, coords.latitude);
+  };
+
+  const updateStoreList = (lat: number, lon: number) => {
+    setLocation(lon, lat);
+    setIsMapMove(false);
+  };
+
+  const updateMapCenter = () => {
+    if (mapRef.current) {
+      const [longitude, latitude] = mapCenter;
+      mapRef.current.setCenter(
+        new window.kakao.maps.LatLng(latitude, longitude),
+      );
+      updateStoreList(latitude, longitude);
+    }
+  };
+
+  const handleReloadStoreList = () => {
+    if (mapRef.current) {
+      const latlng = mapRef.current?.getCenter();
+      if (latlng) {
+        const longitude = latlng.getLng();
+        const latitude = latlng.getLat();
+        updateStoreList(latitude, longitude);
+        // setMapLocation(longitude, latitude);
+      }
+    }
+  };
+
+  const handleClickMapMaker = (data: Marker) => {
+    new Promise((resolve) => {
+      if (clickMarker) {
+        setClickMarker(null);
+      }
+      return resolve("");
+    }).finally(() => {
+      setClickMarker(data);
     });
+  };
 
-    const handleLocationChange = (coords: { latitude: number; longitude: number }) => {
-        setMapCenter([coords.longitude, coords.latitude]);
-        setMapLocation(coords.longitude, coords.latitude);
-    };
+  // 처음 로드될 때 내 위치로 이동
+  useEffect(() => {
+    if (!lon || !lat) {
+      myLocation();
+    } else {
+      setMapCenter([lon, lat]);
+    }
+  }, []);
 
-    const updateStoreList = (lat: number, lon: number) => {
-        setLocation(lon, lat);
-        setIsMapMove(false);
-    };
+  // mapCenter가 업데이트될 때마다 지도 중심 이동
+  useEffect(() => {
+    updateMapCenter();
+  }, [mapCenter]);
 
-    const updateMapCenter = () => {
-        if (mapRef.current) {
-            const [longitude, latitude] = mapCenter;
-            mapRef.current.setCenter(new window.kakao.maps.LatLng(latitude, longitude));
-            updateStoreList(latitude, longitude);
-        }
-    };
+  // 알림이 발생하면 storeList 다시 불러오기
+  useEffect(() => {
+    refetch();
+  }, [notificationList]);
 
-    const handleReloadStoreList = () => {
-        if (mapRef.current) {
-            const latlng = mapRef.current?.getCenter();
-            if (latlng) {
-                const longitude = latlng.getLng();
-                const latitude = latlng.getLat();
-                updateStoreList(latitude, longitude);
-                setMapLocation(longitude, latitude);
+  useEffect(() => {
+    if (!isLoading && stores.length === 0) {
+      toast.warn("주위에 검색 결과가 없습니다.");
+    }
+  }, [isLoading, stores]);
+
+  return (
+    <>
+      <Map
+        center={{ lat: mapCenter[1], lng: mapCenter[0] }}
+        ref={mapRef}
+        className="w-full h-full relative"
+        level={level}
+        onDragEnd={(map) => {
+          const latlng = map.getCenter();
+          setIsMapMove(true);
+          setMapLocation(latlng.getLng(), latlng.getLat());
+        }}
+        onClick={() => setClickMarker(null)}
+        onZoomChanged={(map) => {
+          const latlng = map.getCenter();
+          setMapLocation(latlng.getLng(), latlng.getLat());
+          setZoom(map.getLevel());
+        }}
+      >
+        {stores.map((data) => (
+          <MapMarker
+            key={`${data.name}-${data._id}`}
+            // 나중에 임시데이터 지우면 data.category로 변경
+            category={
+              categories.includes(data.category) ? data.category : "기타"
             }
-        }
-    };
+            coordinates={data.coordinates}
+            title={data.name}
+            onClick={() => handleClickMapMaker(data)}
+          />
+        ))}
 
-    const handleClickMapMaker = (data: Marker) => {
-        new Promise((resolve) => {
-            if (clickMarker) {
-                setClickMarker(null);
-            }
-            return resolve('');
-        }).finally(() => {
-            setClickMarker(data);
-        });
-    };
+        <Search />
+        {/* 맵을 이동한 경우 활성화 */}
+        {isMapMove && (
+          <button
+            className="absolute top-24 left-1/2 -translate-x-1/2 z-10 bg-white text-primary border-1 border-primary rounded-full px-4 py-2 text-xs shadow flex items-center gap-1"
+            onClick={handleReloadStoreList}
+          >
+            <ReloadIcon width={16} height={16} />
+            <span>현 지도에서 검색</span>
+          </button>
+        )}
+        {/* 영업 여부 토글은 로그인 여부에 따라서 달라짐 */}
+        {clickMarker ? null : (
+          <div className="absolute flex items-center justify-between bottom-24 z-10 left-1/2 -translate-x-1/2 w-[calc(100%-50px)] sm:w-[calc(100%-200px)]">
+            <MyLocation setMapCenter={handleLocationChange} />
+            {user?.role === "owner" && (
+              <Toggle text={{ on: "영업중", off: "영업 종료" }} />
+            )}
+          </div>
+        )}
 
-    // 처음 로드될 때 내 위치로 이동
-    useEffect(() => {
-        if (!lon || !lat) {
-            myLocation();
-        } else {
-            setMapCenter([lon, lat]);
-        }
-    }, []);
-
-    // mapCenter가 업데이트될 때마다 지도 중심 이동
-    useEffect(() => {
-        updateMapCenter();
-    }, [mapCenter]);
-
-    // 알림이 발생하면 storeList 다시 불러오기
-    useEffect(() => {
-        refetch();
-    }, [notificationList]);
-
-    useEffect(() => {
-        if (!isLoading && stores.length === 0) {
-            toast.warn('주위에 검색 결과가 없습니다.');
-        }
-    }, [isLoading, stores]);
-
-    return (
-        <>
-            <Map
-                center={{ lat: mapCenter[1], lng: mapCenter[0] }}
-                ref={mapRef}
-                className="w-full h-full relative"
-                level={4}
-                onDragEnd={() => setIsMapMove(true)}
-                onClick={() => setClickMarker(null)}
-            >
-                {stores.map((data) => (
-                    <MapMarker
-                        key={`${data.name}-${data._id}`}
-                        // 나중에 임시데이터 지우면 data.category로 변경
-                        category={categories.includes(data.category) ? data.category : '기타'}
-                        coordinates={data.coordinates}
-                        title={data.name}
-                        onClick={() => handleClickMapMaker(data)}
-                    />
-                ))}
-
-                <Search />
-                {/* 맵을 이동한 경우 활성화 */}
-                {isMapMove && (
-                    <button
-                        className="absolute top-24 left-1/2 -translate-x-1/2 z-10 bg-white text-primary border-1 border-primary rounded-full px-4 py-2 text-xs shadow flex items-center gap-1"
-                        onClick={handleReloadStoreList}
-                    >
-                        <ReloadIcon width={16} height={16} />
-                        <span>현 지도에서 검색</span>
-                    </button>
-                )}
-                {/* 영업 여부 토글은 로그인 여부에 따라서 달라짐 */}
-                {clickMarker ? null : (
-                    <div className="absolute flex items-center justify-between bottom-24 z-10 left-1/2 -translate-x-1/2 w-[calc(100%-50px)] sm:w-[calc(100%-200px)]">
-                        <MyLocation setMapCenter={handleLocationChange} />
-                        {user?.role === 'owner' && <Toggle text={{ on: '영업중', off: '영업 종료' }} />}
-                    </div>
-                )}
-
-                {clickMarker ? (
-                    <div className="absolute inset-x-1/2 -translate-x-1/2 bottom-24 z-10 w-[calc(100%-50px)] sm:w-[calc(100%-280px)] mx-auto ">
-                        <Card
-                            info={{
-                                storeId: clickMarker._id,
-                                category: clickMarker.category,
-                                name: clickMarker.name,
-                                visited: clickMarker.commentCount,
-                                isOpen: clickMarker.isOpen,
-                            }}
-                            bg="black"
-                        />
-                    </div>
-                ) : null}
-            </Map>
-        </>
-    );
+        {clickMarker ? (
+          <div className="absolute inset-x-1/2 -translate-x-1/2 bottom-24 z-10 w-[calc(100%-50px)] sm:w-[calc(100%-280px)] mx-auto ">
+            <Card
+              info={{
+                storeId: clickMarker._id,
+                category: clickMarker.category,
+                name: clickMarker.name,
+                visited: clickMarker.commentCount,
+                isOpen: clickMarker.isOpen,
+              }}
+              bg="black"
+            />
+          </div>
+        ) : null}
+      </Map>
+    </>
+  );
 }

--- a/src/store/mapLocationStore.ts
+++ b/src/store/mapLocationStore.ts
@@ -3,13 +3,17 @@ import { create } from "zustand";
 interface MapLocationState {
   lat: number | null;
   lon: number | null;
+  level: number;
   setLocation: (lon: number, lat: number) => void;
+  setZoom: (size: number) => void;
 }
 
 const useMapLocationStore = create<MapLocationState>((set) => ({
   lon: null,
   lat: null,
+  level: 4,
   setLocation: (lon, lat) => set((state) => ({ ...state, lon, lat })),
+  setZoom: (level) => set((state) => ({ ...state, level })),
 }));
 
 export default useMapLocationStore;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

상세페이지에서 다시 지도로 넘어갈 때 어색하던 부분을 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

기존에 작성한 방식은 사용자가 조회한 위치로 다시 이동됐었습니다.

하지만 실제 사용했을 때 지도를 옮긴 상태로 상세 페이지에 접속했다가 다시 지도로 돌아왔을 때 사용자가 조회 버튼을 클릭한 위치로 이동되는 부분이 어색하게 느껴졌습니다. 

그래서 사용자가 상세페이지 조회하기 전 지도를 이동한 위치로 저장하고, zoom level도 함께 저장해 최대한 자연스럽게 다시 지도로 이동되도록 변경했습니다.

어떻게 되는지 GIF 올리려고했는데 용량이 커서 안올라가네요 ㅠ..... 올릴 수 있을 때 올리겠습니다....

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
