### PR TITLE
fix: 지도 검색 결과 초기화

### DIFF
--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,13 +1,22 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import useStoresStore from "../store/storesStore.ts";
 
 export const useSearch = () => {
   const [searchTerm, setSearchTerm] = useState<string>("");
   const { setSearchTerm: setKeyword } = useStoresStore();
   const inputHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // console.log(e.target.value); // input change 값 확인용
     setSearchTerm(e.target.value);
+
+    // input 값에 변경이 있을 때 빈 값이라면 setKeyword('')로 설정
+    if (!e.target.value) {
+      setKeyword("");
+    }
   };
+
+  // 렌더링 시 setKeyword('')으로 설정
+  useEffect(() => {
+    setKeyword("");
+  }, []);
 
   const clickHandler = () => {
     setSearchTerm("");


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
**렌더링 시 결과 값을 초기화 시켰습니다.**
1. 렌더링 시 `input value`는 사라지기 때문에 그에 맞춰 검색 결과(마커) 또한 초기화 시켜주었습니다.
2. 만약 '고구마' 검색 이후 다시 전체 결과를 보고 싶을 때, 검색 `input`을 지우고 엔터를 다시 눌러줘야 하는 문제가 있었습니다.
  - 이를 해결하기 위해 `onChange`를 통해  `input value`에 값이 없어지면, `setKeyword("");`를 통해 검색 결과를 초기화 시켜주었습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
